### PR TITLE
LCD-46570 Support batch CX

### DIFF
--- a/cloud/helm/client-extension/batch-values.yaml
+++ b/cloud/helm/client-extension/batch-values.yaml
@@ -1,0 +1,35 @@
+clientExtensionConfig:
+  configJson: |
+    {
+      "com.liferay.oauth2.provider.configuration.OAuth2ProviderApplicationHeadlessServerConfiguration~liferay-sample-batch-oauth-application-headless-server" : {
+        ".serviceAddress" : "localhost:8080",
+        ".serviceScheme" : "http",
+        ":configurator:policy" : "force",
+        "baseURL" : "${portalURL}/o/liferay-sample-batch",
+        "buildTimestamp" : 1748461343506,
+        "description" : "",
+        "dxp.lxc.liferay.com.virtualInstanceId" : "default",
+        "homePageURL" : "$[conf:.serviceScheme]://$[conf:.serviceAddress]",
+        "name" : "Liferay Sample OAuth Application Headless Server",
+        "projectId" : "liferaysamplebatch",
+        "projectName" : "liferay-sample-batch",
+        "properties" : [ ],
+        "scopes" : [ "Liferay.Headless.Admin.Workflow.everything", "Liferay.Headless.Batch.Engine.everything", "Liferay.Object.Admin.REST.everything" ],
+        "sourceCodeURL" : "",
+        "type" : "oAuthApplicationHeadlessServer",
+        "typeSettings" : [ ".serviceAddress=localhost:8080", ".serviceScheme=http", "scopes=Liferay.Headless.Admin.Workflow.everything\nLiferay.Headless.Batch.Engine.everything\nLiferay.Object.Admin.REST.everything" ],
+        "webContextPath" : "/liferay-sample-batch"
+      }
+    }
+  domain: "batch.localtest.me"
+  kind: Job
+  localdev: true
+  mountInitConfig: true
+  virtualInstanceId: "main.dxp.localtest.me"
+env:
+  - name: LIFERAY_BATCH_CURL_OPTIONS
+    value: "-v"
+  - name: LIFERAY_BATCH_OAUTH_APP_ERC
+    value: liferay-sample-batch-oauth-application-headless-server
+image:
+  repository: registry:5001/batch

--- a/cloud/helm/client-extension/counter-values.yaml
+++ b/cloud/helm/client-extension/counter-values.yaml
@@ -18,6 +18,7 @@ clientExtensionConfig:
       }
     }
   domain: "counter.localtest.me"
+  kind: Deployment
   localdev: true
   virtualInstanceId: "main.dxp.localtest.me"
 image:

--- a/cloud/helm/client-extension/counter-values.yaml
+++ b/cloud/helm/client-extension/counter-values.yaml
@@ -22,6 +22,8 @@ clientExtensionConfig:
   virtualInstanceId: "main.dxp.localtest.me"
 image:
   repository: registry:5000/counter
+ingress:
+  enabled: true
 livenessProbe:
   httpGet:
     path: /
@@ -29,4 +31,5 @@ readinessProbe:
   httpGet:
     path: /
 service:
+  enabled: true
   port: 80

--- a/cloud/helm/client-extension/css-values.yaml
+++ b/cloud/helm/client-extension/css-values.yaml
@@ -18,6 +18,7 @@ clientExtensionConfig:
       }
     }
   domain: "css.localtest.me"
+  kind: Deployment
   localdev: true
   virtualInstanceId: "main.dxp.localtest.me"
 image:

--- a/cloud/helm/client-extension/css-values.yaml
+++ b/cloud/helm/client-extension/css-values.yaml
@@ -22,3 +22,8 @@ clientExtensionConfig:
   virtualInstanceId: "main.dxp.localtest.me"
 image:
   repository: registry:5000/css
+ingress:
+  enabled: true
+service:
+  enabled: true
+  port: 80

--- a/cloud/helm/client-extension/element-values.yaml
+++ b/cloud/helm/client-extension/element-values.yaml
@@ -18,6 +18,7 @@ clientExtensionConfig:
       }
     }
   domain: "element.localtest.me"
+  kind: Deployment
   localdev: true
   virtualInstanceId: "main.dxp.localtest.me"
 image:

--- a/cloud/helm/client-extension/element-values.yaml
+++ b/cloud/helm/client-extension/element-values.yaml
@@ -22,6 +22,8 @@ clientExtensionConfig:
   virtualInstanceId: "main.dxp.localtest.me"
 image:
   repository: registry:5000/element
+ingress:
+  enabled: true
 livenessProbe:
   httpGet:
     path: /
@@ -29,4 +31,5 @@ readinessProbe:
   httpGet:
     path: /
 service:
+  enabled: true
   port: 80

--- a/cloud/helm/client-extension/favicon-values.yaml
+++ b/cloud/helm/client-extension/favicon-values.yaml
@@ -22,3 +22,8 @@ clientExtensionConfig:
   virtualInstanceId: "main.dxp.localtest.me"
 image:
   repository: registry:5000/favicon
+ingress:
+  enabled: true
+service:
+  enabled: true
+  port: 80

--- a/cloud/helm/client-extension/favicon-values.yaml
+++ b/cloud/helm/client-extension/favicon-values.yaml
@@ -18,6 +18,7 @@ clientExtensionConfig:
       }
     }
   domain: "favicon.localtest.me"
+  kind: Deployment
   localdev: true
   virtualInstanceId: "main.dxp.localtest.me"
 image:

--- a/cloud/helm/client-extension/node-values.yaml
+++ b/cloud/helm/client-extension/node-values.yaml
@@ -56,6 +56,7 @@ clientExtensionConfig:
       }
     }
   domain: "node.localtest.me"
+  kind: Deployment
   localdev: true
   mountInitConfig: true
   virtualInstanceId: "main.dxp.localtest.me"

--- a/cloud/helm/client-extension/node-values.yaml
+++ b/cloud/helm/client-extension/node-values.yaml
@@ -61,6 +61,8 @@ clientExtensionConfig:
   virtualInstanceId: "main.dxp.localtest.me"
 image:
   repository: registry:5000/node
+ingress:
+  enabled: true
 livenessProbe:
   httpGet:
     path: /ready
@@ -68,4 +70,5 @@ readinessProbe:
   httpGet:
     path: /ready
 service:
+  enabled: true
   port: 3001

--- a/cloud/helm/client-extension/springboot-values.yaml
+++ b/cloud/helm/client-extension/springboot-values.yaml
@@ -130,6 +130,8 @@ clientExtensionConfig:
   virtualInstanceId: "main.dxp.localtest.me"
 image:
   repository: registry:5000/springboot
+ingress:
+  enabled: true
 livenessProbe:
   httpGet:
     path: /ready
@@ -137,4 +139,5 @@ readinessProbe:
   httpGet:
     path: /ready
 service:
+  enabled: true
   port: 58081

--- a/cloud/helm/client-extension/springboot-values.yaml
+++ b/cloud/helm/client-extension/springboot-values.yaml
@@ -125,6 +125,7 @@ clientExtensionConfig:
       }
     }
   domain: "springboot.localtest.me"
+  kind: Deployment
   localdev: true
   mountInitConfig: true
   virtualInstanceId: "main.dxp.localtest.me"

--- a/cloud/helm/client-extension/templates/deployment.yaml
+++ b/cloud/helm/client-extension/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.clientExtensionConfig.kind "Deployment" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -91,3 +92,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/cloud/helm/client-extension/templates/deployment.yaml
+++ b/cloud/helm/client-extension/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
               value: /etc/liferay/lxc/ext-init-metadata
             - name: LIFERAY_ROUTES_DXP
               value: /etc/liferay/lxc/dxp-metadata
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/cloud/helm/client-extension/templates/ingress.yaml
+++ b/cloud/helm/client-extension/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ingress.enabled -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -49,3 +50,4 @@ spec:
                   number: {{ $.Values.service.port }}
           {{- end }}
     {{- end }}
+{{- end }}

--- a/cloud/helm/client-extension/templates/job.yaml
+++ b/cloud/helm/client-extension/templates/job.yaml
@@ -1,0 +1,83 @@
+{{- if eq .Values.clientExtensionConfig.kind "Job" -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "liferay-client-extension.fullname" . }}
+  labels:
+    {{- include "liferay-client-extension.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 4
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "liferay-client-extension.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      restartPolicy: Never
+      serviceAccountName: {{ include "liferay-client-extension.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          env:
+            - name: LIFERAY_ROUTES_CLIENT_EXTENSION
+              value: /etc/liferay/lxc/ext-init-metadata
+            - name: LIFERAY_ROUTES_DXP
+              value: /etc/liferay/lxc/dxp-metadata
+            {{- range .Values.env }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /etc/liferay/lxc/dxp-metadata
+              name: lxc-dxp-metadata
+              readOnly: true
+            {{- if .Values.clientExtensionConfig.mountInitConfig }}
+            - mountPath: /etc/liferay/lxc/ext-init-metadata
+              name: lxc-ext-init-metadata
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: lxc-dxp-metadata
+          configMap:
+            name: {{ include "dxp-configmap.name" . }}
+        {{- if .Values.clientExtensionConfig.mountInitConfig }}
+        - name: lxc-ext-init-metadata
+          configMap:
+            name: {{ include "liferay-client-extension.ext-init-configmap.name" . }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/cloud/helm/client-extension/templates/service.yaml
+++ b/cloud/helm/client-extension/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -13,3 +14,4 @@ spec:
       name: http
   selector:
     {{- include "liferay-client-extension.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/cloud/helm/client-extension/values.yaml
+++ b/cloud/helm/client-extension/values.yaml
@@ -7,6 +7,7 @@ autoscaling:
 clientExtensionConfig:
   configJson: ""
   domain: ""
+  kind: ""
   localdev: false
   mountInitConfig: false
   virtualInstanceId: ""

--- a/cloud/helm/client-extension/values.yaml
+++ b/cloud/helm/client-extension/values.yaml
@@ -19,6 +19,7 @@ imagePullSecrets: []
 ingress:
   annotations: {}
   className: ""
+  enabled: false
   hosts: []
   tls: []
 livenessProbe:
@@ -38,6 +39,7 @@ replicaCount: 1
 resources: {}
 securityContext: {}
 service:
+  enabled: false
   port: 80
   type: ClusterIP
 serviceAccount:

--- a/cloud/helm/client-extension/values.yaml
+++ b/cloud/helm/client-extension/values.yaml
@@ -11,6 +11,7 @@ clientExtensionConfig:
   localdev: false
   mountInitConfig: false
   virtualInstanceId: ""
+env: []
 fullnameOverride: ""
 image:
   pullPolicy: Always


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-46567

https://liferay.atlassian.net/browse/LCD-46570

---

# Usage

## Setup

### Deploy DXP

1. Prepare your mind to deploy DXP from helm... you need to deploy from the helm chart locally and provide some custom values
2. First customization: instead of `main.dxp.docker.localhost`, you're going to need to use `main.dxp.localtest.me`. This is because `docker.localhost` will bypass DNS resolution using the top-level localhost resolution... but you need it to resolve through coredns when working locally.
3. Second customization: do not use `latest` tag for DXP... you need to use `7.4.13` for now because of issues on other images. I've had luck with `7.4.13.nightly-d8.0.1-20250307212055`.
4. Final customization: add `web.server.protocol=http` to the `portalProperties` field in `/cloud/helm/default/values.yaml`. This is needed for working locally.
5. After above customizations on the values file, follow [Basic Local Chart Deployment](https://liferay.atlassian.net/wiki/spaces/LC/pages/3787980805/Basic+Local+Chart+Deployment) steps to deploy Helm-based DXP locally

### Update `/etc/hosts` to resolve local image registry

1. Add `127.0.0.1 registry` entry to `/etc/hosts`

### Update coredns to resolve DXP endpoint

1. `./scripts/append-nodehost.sh main.dxp.localtest.me`

## Sample batch CX

1. Copy `liferay-portal/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-batch` into `<workspace>/client-extensions` directory
2. `cd <workspace>/client-extensions`
3. `gradle build`
4. `cd <workspace>/client-extensions/liferay-sample-batch/build/liferay-client-extension-build`
5. `docker build --tag batch`
6. `docker tag element registry:5000/batch`
7. `docker push registry:5000/batch`
8. `helm upgrade batch <liferay-portal>/cloud/helm/client-extension -i -f <liferay-portal>/cloud/helm/client-extension/batch-values.yaml`
9. Verify batch Job ran
10. Verify batch CX created "Sample" Object on DXP